### PR TITLE
Simplify imports tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,17 +36,7 @@ requirements:
 test:
   imports:
     - optuna
-    - optuna.integration
-    - optuna.pruners
-    - optuna.samplers
-    - optuna.storages
-    - optuna.testing
     - tests
-    - tests.integration_tests
-    - tests.pruners_tests
-    - tests.samplers_tests
-    - tests.storages_tests
-    - tests.storages_tests.rdb_tests
   commands:
     - optuna --help
   source_files:


### PR DESCRIPTION
Import tests are not up to date so we should either update them or maybe simplify/skip most of them. 

This PR proposes the latter based on experience that we haven't caught failures here before. Usually these types of error should have been addressed earlier.