### PR TITLE
[ci skip] adding user @contramundum53

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @HideakiImamura @g-votte @hvy @iwiwi @not522 @sile @smly @toshihikoyanase @ytsmiling
+* @contramundum53 @HideakiImamura @g-votte @hvy @iwiwi @not522 @sile @smly @toshihikoyanase @ytsmiling

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - contramundum53
     - g-votte
     - HideakiImamura
     - hvy


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @contramundum53 as instructed in #35.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #35